### PR TITLE
Develop – edited error message

### DIFF
--- a/lib/babelyoda.rb
+++ b/lib/babelyoda.rb
@@ -304,7 +304,7 @@ namespace :babelyoda do
             spec.engine.drop_keyset!(keyset_name)
           end
         else
-          $logger.error "Please provide keyset names to drop in the KEYSET environment variable. " +
+          $logger.error "Please provide keyset names to drop in the KEYSETS environment variable. " +
                         "Separate by commas. Use * for ALL."
         end
       end


### PR DESCRIPTION
<b>Tiny fix</b>: the error message for <code>babelyoda:remote:drop_keysets</code> returned misleading instruction, telling to use <code>KEYSET</code> env variable. 

While the var is actually named <code>KEYSETS</code>.
