### PR TITLE
Translations length warnings

### DIFF
--- a/lib/babelyoda/length_checker.rb
+++ b/lib/babelyoda/length_checker.rb
@@ -1,0 +1,67 @@
+module Babelyoda
+  class LengthChecker
+    def initialize(dev_language, params)
+      @dev_language = dev_language
+      @params = params
+    end
+
+    def long_translations(keyset)
+      long_translations = {}
+
+      keyset.keys.each_value do |key|
+        dev_value = key.values[@dev_language]
+        dev_text = longest_translation(dev_value)
+        dev_len = dev_text.length.to_f
+
+        key.values.each_value do |value|
+          text = longest_translation(value)
+          len = text.nil? ? 0 : text.length
+          ratio = len/dev_len
+          big_ratio = ratio >= @params.ratio
+          big_delta = (len - dev_len) >= @params.delta
+
+          if big_ratio && big_delta
+            lang = value.language.to_sym
+            problem = Babelyoda::LongTranslation.new(dev_text, text, key.context)
+            if long_translations.has_key?(lang)
+              long_translations[lang].push(problem)
+            else
+              long_translations[lang] = [problem]
+            end
+          end
+        end
+      end
+      long_translations
+    end
+
+  private
+
+    def longest_translation(localizaition_value)
+      if localizaition_value.plural?
+        translation = localizaition_value.text.values.max_by {|str| str.nil? ? 0 : str.length}
+      else
+        translation = localizaition_value.text
+      end
+      translation
+    end
+  end
+
+  class LongTranslation
+    attr_accessor :dev_text
+    attr_accessor :text
+    attr_accessor :context
+    
+    def initialize(dev_text, text, context)
+      @dev_text = dev_text
+      @other_text = text
+      @context = context
+    end
+   
+    def ==(other_obj)
+      dev_texts_equal = @dev_text == other_obj.dev_text
+      texts_equal = @text == other_obj.text
+      contexts_equal = @context == other_obj.context
+      dev_texts_equal && texts_equal && contexts_equal
+    end
+  end
+end

--- a/lib/babelyoda/length_checker.rb
+++ b/lib/babelyoda/length_checker.rb
@@ -56,5 +56,12 @@ module Babelyoda
       @text = text
       @context = context
     end
+    
+    def ==(other_obj)
+      dev_texts_equal = @dev_text == other_obj.dev_text
+      texts_equal = @text == other_obj.text
+      contexts_equal = @context == other_obj.context
+      dev_texts_equal && texts_equal && contexts_equal
+   end
   end
 end

--- a/lib/babelyoda/length_checker.rb
+++ b/lib/babelyoda/length_checker.rb
@@ -22,11 +22,11 @@ module Babelyoda
 
           if big_ratio && big_delta
             lang = value.language.to_sym
-            problem = Babelyoda::LongTranslation.new(dev_text, text, key.context)
+            translation = Babelyoda::LongTranslation.new(dev_text, text, key.context)
             if long_translations.has_key?(lang)
-              long_translations[lang].push(problem)
+              long_translations[lang].push(translation)
             else
-              long_translations[lang] = [problem]
+              long_translations[lang] = [translation]
             end
           end
         end
@@ -53,15 +53,8 @@ module Babelyoda
     
     def initialize(dev_text, text, context)
       @dev_text = dev_text
-      @other_text = text
+      @text = text
       @context = context
-    end
-   
-    def ==(other_obj)
-      dev_texts_equal = @dev_text == other_obj.dev_text
-      texts_equal = @text == other_obj.text
-      contexts_equal = @context == other_obj.context
-      dev_texts_equal && texts_equal && contexts_equal
     end
   end
 end

--- a/lib/babelyoda/length_checker_params.rb
+++ b/lib/babelyoda/length_checker_params.rb
@@ -1,0 +1,10 @@
+require_relative 'specification_loader'
+
+module Babelyoda
+  class LengthCheckerParams
+    include Babelyoda::SpecificationLoader
+
+    attr_accessor :ratio
+    attr_accessor :delta
+  end
+end

--- a/lib/babelyoda/specification.rb
+++ b/lib/babelyoda/specification.rb
@@ -16,6 +16,7 @@ module Babelyoda
     attr_accessor :xib_files
     attr_accessor :strings_files
     attr_accessor :scm
+    attr_accessor :length_checker_params
 
     FILENAME = 'Babelfile'
 

--- a/spec/lib/babelyoda/length_checker_spec.rb
+++ b/spec/lib/babelyoda/length_checker_spec.rb
@@ -1,0 +1,106 @@
+require 'babelyoda/keyset'
+require 'babelyoda/length_checker'
+require 'babelyoda/length_checker_params'
+require 'babelyoda/strings_lexer'
+require 'babelyoda/strings_parser'
+
+describe "length checker" do
+  before(:example) do
+    @ratio = 2
+    @delta = 3
+    @params = Babelyoda::LengthCheckerParams.new()
+    @params.ratio = @ratio
+    @params.delta = @delta
+    @dev_lang = :dev_lang
+    @lang1 = :lang1
+    @lang2 = :lang2
+    @checker = Babelyoda::LengthChecker.new(@dev_lang, @params)
+  end
+  
+  describe "finding long translations in keyset" do
+    def add_lang_strings_to_keyset(lang, strings, keyset)
+      lexer = Babelyoda::StringsLexer.new    
+      parser = Babelyoda::StringsParser.new(lexer, lang)
+      parser.parse(strings) do |record|
+        keyset.merge_key!(record)
+      end
+    end
+    
+    def generate_keyset(dev_str, lang1_str, lang2_str)
+      keyset = Babelyoda::Keyset.new("test_keyset")
+      add_lang_strings_to_keyset(@dev_lang, dev_str, keyset)
+      add_lang_strings_to_keyset(@lang1, lang1_str, keyset)
+      add_lang_strings_to_keyset(@lang2, lang2_str, keyset)
+      keyset
+    end
+    
+    it "doesn't find anything in empty keyset" do
+      empty_keyset = Babelyoda::Keyset.new("empty_keyset")
+      
+      expect(@checker.long_translations(empty_keyset)).to be_empty
+    end
+    
+    context "when has only non-plural keys" do 
+      it "finds long translations" do
+        dev_str = <<-EOF 
+        /* comment hi */
+        "Hi" = "Hi";
+        /* comment hello */
+        "Hello" = "Hello";
+        EOF
+        
+        lang1_str = <<-EOF 
+        /* comment hi */
+        "Hi" = "HiHi";
+        /* comment hello */
+        "Hello" = "HelloHello";
+        EOF
+        
+        lang2_str = <<-EOF 
+        /* comment hi */
+        "Hi" = "HiHiHiHi";
+        /* comment hello */
+        "Hello" = "HelloHelloHello";
+        EOF
+        
+        keyset = generate_keyset(dev_str, lang1_str, lang2_str)
+        lang1_hello_problem = Babelyoda::LongTranslation.new("Hello", "HelloHello", "comment hello")
+        lang2_hi_problem = Babelyoda::LongTranslation.new("Hi", "HiHiHiHi", "comment hi")
+        lang2_hello_problem = Babelyoda::LongTranslation.new("Hello", "HelloHelloHello", "comment hello")
+        expected = {}
+        expected[@lang1] = [lang1_hello_problem]
+        expected[@lang2] = [lang2_hi_problem, lang2_hello_problem]
+      
+        expect(@checker.long_translations(keyset)).to eq(expected) 
+      end
+    end
+    
+    context "when has plural keys" do
+      it "compares longest plural variants" do
+        dev_str = <<-EOF
+        /* comment min */
+        "%[one]u min" = "min";
+        "%[many]u min" = "minutes";
+        EOF
+        
+        lang1_str = <<-EOF
+        /* comment min */
+        "%[one]u min" = "minminmin";
+        "%[many]u min" = "minutes";
+        EOF
+        
+        lang2_str = <<-EOF
+        /* comment min */
+        "%[one]u min" = "minminmin";
+        "%[many]u min" = "minutesminutes";
+        EOF
+        
+        keyset = generate_keyset(dev_str, lang1_str, lang2_str)
+        lang2_problem = Babelyoda::LongTranslation.new("minutes", "minutesminutes", "comment min")
+        expected = {@lang2 => [lang2_problem]}
+        
+        expect(@checker.long_translations(keyset)).to eq(expected)  
+      end
+    end
+  end
+end

--- a/templates/Babelfile.erb
+++ b/templates/Babelfile.erb
@@ -24,4 +24,9 @@ Babelyoda::Specification.new do |s|
 	s.resources_folder = 'Resources'
 	s.xib_files = FileList['{Classes,Resources}/**/en.lproj/*.{xib}']
 	s.strings_files = FileList['{Classes,Resources}/**/en.lproj/*.{strings}']
+	
+	s.length_checker_params = Babelyoda::LengthCheckerParams.new do |p|
+		p.ratio = 1.5
+		p.delta = 10
+	end
 end


### PR DESCRIPTION
Sometimes translation is much longer than original string and it can cause problems in UI. It is useful to have an ability to see all such cases. 
This PR adds an optional babelyoda rake task to run such a check. Translation is considered "long" if it is more than N% longer AND more than M symbols longer than development string. Two factors allow to exclude short words cases when N% longer means just 2-3 symbols. N and M are set via babelyoda spec.
